### PR TITLE
fix: make follow channel-related processes to proto schemas

### DIFF
--- a/workspaces/app/src/features/channel/components/channel-list/__stories__/channel-list.stories.tsx
+++ b/workspaces/app/src/features/channel/components/channel-list/__stories__/channel-list.stories.tsx
@@ -9,15 +9,15 @@ export default meta;
 
 const mockChannels = [
   {
-    id: 1,
+    id: "1",
     name: "general",
   },
   {
-    id: 2,
+    id: "2",
     name: "random",
   },
   {
-    id: 3,
+    id: "3",
     name: "random2",
   },
 ];

--- a/workspaces/app/src/features/channel/components/channel-list/channel-list.tsx
+++ b/workspaces/app/src/features/channel/components/channel-list/channel-list.tsx
@@ -4,7 +4,7 @@ import { Hash } from "react-feather";
 import { clsx } from "@/libs/clsx";
 
 interface Channel {
-  id: number;
+  id: string;
   name: string;
   active?: boolean;
   hasNotification?: boolean;

--- a/workspaces/app/src/features/channel/components/layout/__stories__/layout.stories.tsx
+++ b/workspaces/app/src/features/channel/components/layout/__stories__/layout.stories.tsx
@@ -9,11 +9,11 @@ export default meta;
 
 const mockChannels = [
   {
-    id: 1,
+    id: "1",
     name: "Channel 1",
   },
   {
-    id: 2,
+    id: "2",
     name: "Channel 2",
   },
 ];

--- a/workspaces/app/src/features/channel/components/layout/layout.tsx
+++ b/workspaces/app/src/features/channel/components/layout/layout.tsx
@@ -7,7 +7,7 @@ import { ProfileBox } from "../profile-box";
 
 interface ChannelLayoutProps {
   channels: {
-    id: number;
+    id: string;
     name: string;
   }[];
   isChannelsLoading?: boolean;

--- a/workspaces/app/src/features/channel/hooks/use-create-channel.ts
+++ b/workspaces/app/src/features/channel/hooks/use-create-channel.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRepositories } from "@/hooks/repository";
+import { create } from "@bufbuild/protobuf";
+import { CreateChannelRequestSchema } from "@meline/schema/schema/request/channel_request_pb.js";
 
 interface UseCreateChannelsOptions {
   onCreated?: () => void;
@@ -19,7 +21,9 @@ export const useCreateChannels = ({
 
   return useMutation({
     mutationFn: async (param: MutationParam) => {
-      return channelRepository.createChannel(param);
+      return channelRepository.createChannel(
+        create(CreateChannelRequestSchema, param),
+      );
     },
     onSettled: () => {
       client.invalidateQueries({

--- a/workspaces/app/src/features/channel/hooks/use-joined-channels.ts
+++ b/workspaces/app/src/features/channel/hooks/use-joined-channels.ts
@@ -1,11 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRepositories } from "@/hooks/repository";
+import { create } from "@bufbuild/protobuf";
+import { GetAllChannelsRequestSchema } from "@meline/schema/schema/request/channel_request_pb.js";
 
 export const useJoinedChannels = () => {
   const { channelRepository } = useRepositories();
 
   return useQuery({
     queryKey: channelRepository.getJoinedChannels$$key(),
-    queryFn: () => channelRepository.getJoinedChannels(),
+    queryFn: () =>
+      channelRepository.getJoinedChannels(
+        create(GetAllChannelsRequestSchema, {}),
+      ),
   });
 };

--- a/workspaces/app/src/repositories/channel.ts
+++ b/workspaces/app/src/repositories/channel.ts
@@ -36,7 +36,7 @@ export class ChannelRepositoryImpl implements IChannelRepository {
       throw new Error("Failed to create channel");
     }
 
-    return create(CreateChannelResponseSchema, await res.json());
+    return create(CreateChannelResponseSchema, {}); // レスポンスが空なのでawait res.json()するとエラーになる
   }
 
   async getJoinedChannels() {


### PR DESCRIPTION
結局悪いのは`google.protobuf.Empty`を使ってないからという結論になった